### PR TITLE
feature : 내 찜목록 조회추가, 마이페이지 찜 추가/삭제 기능추가

### DIFF
--- a/tripeer/src/main/java/com/j10d207/tripeer/place/controller/PlaceController.java
+++ b/tripeer/src/main/java/com/j10d207/tripeer/place/controller/PlaceController.java
@@ -125,14 +125,4 @@ public class PlaceController {
         return Response.of(HttpStatus.OK, "모든 도시, 타운 조회", townService.getAllCityAndTown());
     }
 
-    //즐겨찾기 추가
-    @PostMapping("/wishList/{spotInfoId}")
-    public Response<?> addWishList(@PathVariable("spotInfoId") int spotInfoId, @AuthenticationPrincipal CustomOAuth2User user) {
-        try {
-            planService.addWishList(spotInfoId, user.getUserId());
-            return Response.of(HttpStatus.OK, "즐겨찾기 추가 완료", null);
-        } catch (Exception e) {
-            throw new RuntimeException(e);
-        }
-    }
 }

--- a/tripeer/src/main/java/com/j10d207/tripeer/place/db/ContentTypeEnum.java
+++ b/tripeer/src/main/java/com/j10d207/tripeer/place/db/ContentTypeEnum.java
@@ -15,7 +15,7 @@ public class ContentTypeEnum {
         SPORTS(28, "레포츠"),
         ACCOMMODATION(32, "숙박"),
         SHOPPING(38, "쇼핑"),
-        RESTAURANT(39, "음식점");
+        RESTAURANT(39, "맛집");
 
         private final int code;
         private final String name;
@@ -26,6 +26,18 @@ public class ContentTypeEnum {
         for (ContentTypeListEnum contentType : ContentTypeListEnum.values()) {
             if (contentType.getCode() == code) {
                 return contentType.getName();
+            }
+        }
+        return null; // 매칭되는 값이 없을 경우 null 반환
+    }
+
+    // 상수 값을 대분류 이름으로 변환하는 메서드
+    public static String getMajorNameByCode(int code) {
+        for (ContentTypeListEnum contentType : ContentTypeListEnum.values()) {
+            if (contentType.getCode() == code && (code == 32 || code == 39)) {
+                return contentType.getName();
+            } else if (contentType.getCode() == code) {
+                return "명소";
             }
         }
         return null; // 매칭되는 값이 없을 경우 null 반환

--- a/tripeer/src/main/java/com/j10d207/tripeer/plan/controller/PlanController.java
+++ b/tripeer/src/main/java/com/j10d207/tripeer/plan/controller/PlanController.java
@@ -100,13 +100,6 @@ public class PlanController {
         return Response.of(HttpStatus.OK, "플랜버킷 관광지 삭제 완료", null);
     }
 
-    //즐겨찾기 추가
-    @PostMapping("/wishlist/{spotInfoId}")
-    public Response<?> addWishList(@PathVariable("spotInfoId") int spotInfoId, @AuthenticationPrincipal CustomOAuth2User user) {
-        planService.addWishList(spotInfoId, user.getUserId());
-        return Response.of(HttpStatus.OK, "즐겨찾기 추가 완료", null);
-    }
-
     //즐겨찾기 조회
     @GetMapping("wishlist/{planId}")
     public Response<List<SpotSearchResDTO>> getWishList(@AuthenticationPrincipal CustomOAuth2User user, @PathVariable("planId") long planId) {

--- a/tripeer/src/main/java/com/j10d207/tripeer/plan/service/PlanService.java
+++ b/tripeer/src/main/java/com/j10d207/tripeer/plan/service/PlanService.java
@@ -30,8 +30,6 @@ public interface PlanService {
     public void addPlanSpot(long planId, int spotInfoId, long userId);
     //플랜버킷 관광지 삭제
     public void delPlanSpot(long planId, int spotInfoId, long userId);
-    //즐겨찾기 추가
-    public void addWishList(int spotInfoId, long userId);
     //즐겨찾기 조회
     public List<SpotSearchResDTO> getWishList(long userId, long planId);
     //플린 디테일 저장

--- a/tripeer/src/main/java/com/j10d207/tripeer/plan/service/PlanServiceImpl.java
+++ b/tripeer/src/main/java/com/j10d207/tripeer/plan/service/PlanServiceImpl.java
@@ -355,25 +355,6 @@ public class PlanServiceImpl implements PlanService {
         }
     }
 
-    //즐겨찾기 추가
-    @Override
-    public void addWishList(int spotInfoId, long userId) {
-        Optional<WishListEntity> optionalWishList = wishListRepository.findBySpotInfo_SpotInfoIdAndUser_UserId(spotInfoId, userId);
-        if (optionalWishList.isPresent()) {
-            wishListRepository.delete(optionalWishList.get());
-        } else {
-            WishListEntity wishList = WishListEntity.builder()
-                    .user(UserEntity.builder()
-                            .userId(userId)
-                            .build())
-                    .spotInfo(SpotInfoEntity.builder()
-                            .spotInfoId(spotInfoId)
-                            .build())
-                    .build();
-            wishListRepository.save(wishList);
-        }
-    }
-
     //즐겨찾기 조회
     @Override
     public List<SpotSearchResDTO> getWishList(long userId, long planId) {

--- a/tripeer/src/main/java/com/j10d207/tripeer/user/controller/UserController.java
+++ b/tripeer/src/main/java/com/j10d207/tripeer/user/controller/UserController.java
@@ -65,6 +65,20 @@ public class UserController {
         return Response.of(HttpStatus.OK, "내 정보 불러오기 완료", userService.getMyInfo(user.getUserId()));
     }
 
+    //내 찜목록 전체 불러오기
+    @GetMapping("/mypage/wishlist")
+    public Response<List<UserDTO.Wishlist>> myWishlist(@AuthenticationPrincipal CustomOAuth2User user) {
+        return Response.of(HttpStatus.OK, "내 찜목록 불러오기 완료", userService.getMyWishlist(user.getUserId()));
+    }
+
+    //즐겨찾기 추가
+    @PostMapping("/wishlist/{spotInfoId}")
+    public Response<?> addWishList(@PathVariable("spotInfoId") int spotInfoId,
+                                   @AuthenticationPrincipal CustomOAuth2User user) {
+        userService.addWishList(spotInfoId, user.getUserId());
+        return Response.of(HttpStatus.OK, "즐겨찾기 추가 완료", null);
+    }
+
     //내 정보 수정
     @PatchMapping("/myinfo")
     public Response<?> myInfoModify(@AuthenticationPrincipal CustomOAuth2User user, @Valid @RequestBody InfoReq infoReq) {

--- a/tripeer/src/main/java/com/j10d207/tripeer/user/db/entity/WishListEntity.java
+++ b/tripeer/src/main/java/com/j10d207/tripeer/user/db/entity/WishListEntity.java
@@ -27,4 +27,15 @@ public class WishListEntity {
     @ManyToOne
     @JoinColumn(name = "SPOT_INFO_ID")
     private SpotInfoEntity spotInfo;
+
+    public static WishListEntity CreateWishListEntity (int spotInfoId, long userId) {
+        return WishListEntity.builder()
+                .user(UserEntity.builder()
+                        .userId(userId)
+                        .build())
+                .spotInfo(SpotInfoEntity.builder()
+                        .spotInfoId(spotInfoId)
+                        .build())
+                .build();
+    }
 }

--- a/tripeer/src/main/java/com/j10d207/tripeer/user/dto/res/UserDTO.java
+++ b/tripeer/src/main/java/com/j10d207/tripeer/user/dto/res/UserDTO.java
@@ -1,7 +1,9 @@
 package com.j10d207.tripeer.user.dto.res;
 
+import com.j10d207.tripeer.place.db.ContentTypeEnum;
 import com.j10d207.tripeer.user.db.entity.CoworkerEntity;
 import com.j10d207.tripeer.user.db.entity.UserEntity;
+import com.j10d207.tripeer.user.db.entity.WishListEntity;
 import lombok.Builder;
 import lombok.Getter;
 import org.springframework.security.core.Authentication;
@@ -38,6 +40,36 @@ public class UserDTO {
                     .style1(userEntity.getStyle1())
                     .style2(userEntity.getStyle2())
                     .style3(userEntity.getStyle3())
+                    .build();
+        }
+    }
+
+    @Getter
+    @Builder
+    public static class Wishlist {
+        private long wishlistId;
+        private long cityId;
+        private long townId;
+        private long spotInfoId;
+        private String title;
+        private String contentType;
+        private String addr;
+        private Double latitude;
+        private Double longitude;
+        private String img;
+
+        public static Wishlist fromEntity(WishListEntity wishListEntity) {
+            return Wishlist.builder()
+                    .wishlistId(wishListEntity.getWishlistId())
+                    .cityId(wishListEntity.getSpotInfo().getTown().getTownPK().getCity().getCityId())
+                    .townId(wishListEntity.getSpotInfo().getTown().getTownPK().getTownId())
+                    .spotInfoId(wishListEntity.getSpotInfo().getSpotInfoId())
+                    .title(wishListEntity.getSpotInfo().getTitle())
+                    .contentType(ContentTypeEnum.getMajorNameByCode(wishListEntity.getSpotInfo().getContentTypeId()))
+                    .addr(wishListEntity.getSpotInfo().getAddr1())
+                    .latitude(wishListEntity.getSpotInfo().getLatitude())
+                    .longitude(wishListEntity.getSpotInfo().getLongitude())
+                    .img(wishListEntity.getSpotInfo().getFirstImage())
                     .build();
         }
     }

--- a/tripeer/src/main/java/com/j10d207/tripeer/user/service/UserService.java
+++ b/tripeer/src/main/java/com/j10d207/tripeer/user/service/UserService.java
@@ -26,6 +26,10 @@ public interface UserService {
     public List<UserDTO.Search> userSearch(String nickname);
     //내 정보 불러오기
     public UserDTO.Info getMyInfo(long userId);
+    //내 찜목록 전체 불러오기
+    public List<UserDTO.Wishlist> getMyWishlist(long userId);
+    //즐겨찾기 추가
+    public void addWishList(int spotInfoId, long userId);
     //access 토큰 재발급
     public void tokenRefresh(String token, Cookie[] cookies, HttpServletResponse response);
 


### PR DESCRIPTION
## PR 유형
어떤 변경 사항이 있나요?

- [X] 새로운 기능 추가
- [ ] 버그 수정
- [X] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 주요 변경사항

- user 도메인에 내 찜목록 전체 조회 기능 추가

- 찜하기 추가/삭제 기능 plan 도메인에서 user 도메인으로 변경

- ContentTypeEnum 에서 '음식점'을 '맛집'으로 변경

## For Reviewer

- 기존 찜목록은 plan 생성 중 추가/삭제할 수 있었고 현재 plan에 담겨 있는지 여부를 체크 하였음.
 그래서 plan 도메인에 작성되었으나 개편시 찜목록 페이지를 내가 한것을 중심으로 다루기 때문에 user로 분리

- user 도메인에 조회/추가/삭제 기능 추가

- plan 도메인에 작성된것은 현재 PR 보낸것에 반영하겠습니다.

- ContentTypeEnum 에서 대분류로 이름을 반환하는 기능 추가