### PR TITLE
fix : plan 사용하지 않는 컬럼 삭제

### DIFF
--- a/tripeer/src/main/java/com/j10d207/tripeer/history/service/HistoryServiceImpl.java
+++ b/tripeer/src/main/java/com/j10d207/tripeer/history/service/HistoryServiceImpl.java
@@ -51,7 +51,7 @@ public class HistoryServiceImpl implements HistoryService {
 			.orElseThrow(() -> new CustomException(ErrorCode.NOT_HAS_COWORKER));
 		return coworkerList.stream()
 			.map(CoworkerEntity::getPlan)
-			.filter(plan -> plan.getVehicle().equals("history"))
+			.filter(PlanEntity::getIsSaved)
 			.map(PlanInfoRes::from)
 			.toList();
 	}
@@ -72,10 +72,10 @@ public class HistoryServiceImpl implements HistoryService {
 		long planId = planSaveReq.getPlanId();
 		List<PlanDayEntity> planDayEntityList = planDayRepository.findAllByPlan_PlanIdOrderByDayAsc(planId);
 		PlanEntity planEntity = planRepository.findByPlanId(planId);
-		if (planEntity.getVehicle().equals("history")) {
+		if (planEntity.getIsSaved()) {
 			throw new CustomException(ErrorCode.HISTORY_ALREADY_EXISTS);
 		}
-		planEntity.setVehicle("history");
+		planEntity.setIsSaved(true);
 		planRepository.save(planEntity);
 		List<PlanDetailEntity> revokePlanDetailList = new ArrayList<>();
 		for (int day = 1; day < totalYList.size(); day++) {
@@ -92,7 +92,7 @@ public class HistoryServiceImpl implements HistoryService {
 					List<Object> timeList = tmp;
 					if (timeList.get(1).equals("2")) {
 						planDetailRepository.deleteAll(revokePlanDetailList);
-						planEntity.setVehicle("private");
+						planEntity.setIsSaved(false);
 						planRepository.save(planEntity);
 						throw new CustomException(ErrorCode.UNSUPPORTED_JSON_TYPE);
 					}
@@ -162,7 +162,7 @@ public class HistoryServiceImpl implements HistoryService {
 		planDayEntityList.stream()
 			.map(PlanDayEntity::getPlanDetailList)  // PlanDayEntity에서 PlanDetailEntity 리스트를 가져옴
 			.forEach(planDetailRepository::deleteAll);  // 가져온 각각의 PlanDetailEntity 리스트를 삭제
-		plan.setVehicle("private");
+		plan.setIsSaved(false);
 		planRepository.save(plan);
 		return "복구 성공";
 	}

--- a/tripeer/src/main/java/com/j10d207/tripeer/plan/db/entity/PlanDayEntity.java
+++ b/tripeer/src/main/java/com/j10d207/tripeer/plan/db/entity/PlanDayEntity.java
@@ -37,8 +37,6 @@ public class PlanDayEntity {
 	private PlanEntity plan;
 
     private LocalDate day;
-    private LocalTime startTime;
-    private String vehicle;
 
     @OneToMany(fetch = FetchType.LAZY)
     @JoinColumn(name = "PLAN_DAY_ID")
@@ -52,7 +50,6 @@ public class PlanDayEntity {
         return PlanDayEntity.builder()
                 .plan(planEntity)
                 .day(createResultInfo.getStartDay().plusDays(i))
-                .vehicle(createResultInfo.getVehicle())
                 .build();
 
     }

--- a/tripeer/src/main/java/com/j10d207/tripeer/plan/db/entity/PlanEntity.java
+++ b/tripeer/src/main/java/com/j10d207/tripeer/plan/db/entity/PlanEntity.java
@@ -34,7 +34,7 @@ public class PlanEntity {
 	@Setter
 	private String title;
 	@Setter
-	private String vehicle;
+	private Boolean isSaved;
 	private LocalDate startDate;
 	private LocalDate endDate;
 	private LocalDate createDate;
@@ -54,7 +54,7 @@ public class PlanEntity {
     public static PlanEntity fromDto(PlanDetailMainDTO.CreateResultInfo CreateResultInfo) {
         return PlanEntity.builder()
                 .title(CreateResultInfo.getTitle())
-                .vehicle(CreateResultInfo.getVehicle())
+                .isSaved(CreateResultInfo.getIsSaved())
                 .startDate(CreateResultInfo.getStartDay())
                 .endDate(CreateResultInfo.getEndDay())
                 .createDate(LocalDate.now(ZoneId.of("Asia/Seoul")))

--- a/tripeer/src/main/java/com/j10d207/tripeer/plan/dto/req/PlanCreateInfoReq.java
+++ b/tripeer/src/main/java/com/j10d207/tripeer/plan/dto/req/PlanCreateInfoReq.java
@@ -18,7 +18,7 @@ public class PlanCreateInfoReq {
     private String title;
     @NotNull(message = "선택된 여행지가 없습니다. townList가 null입니다. ")
     private List<TownDTO> townList;
-    private String vehicle;
+    private Boolean isSaved;
     @Future(message = "과거 일자를 계획할 수 없습니다.")
     private LocalDate startDay;
     @Future(message = "과거 일자를 계획할 수 없습니다.")

--- a/tripeer/src/main/java/com/j10d207/tripeer/plan/dto/res/PlanDetailMainDTO.java
+++ b/tripeer/src/main/java/com/j10d207/tripeer/plan/dto/res/PlanDetailMainDTO.java
@@ -35,7 +35,7 @@ public class PlanDetailMainDTO {
         private long planId;
         private String title;
         private List<TownDTO> townList;
-        private String vehicle;
+        private Boolean isSaved;
         private LocalDate startDay;
         private LocalDate endDay;
         private LocalDate createDay;
@@ -45,7 +45,7 @@ public class PlanDetailMainDTO {
             return CreateResultInfo.builder()
                     .title(createInfo.getTitle())
                     .townList(createInfo.getTownList())
-                    .vehicle(createInfo.getVehicle())
+                    .isSaved(createInfo.getIsSaved())
                     .startDay(createInfo.getStartDay())
                     .endDay(createInfo.getEndDay())
                     .createDay(LocalDate.now(ZoneId.of("Asia/Seoul")))


### PR DESCRIPTION
## PR 유형
어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 주요 변경사항

- plan 에서 사용하지 않는 컬럼 엔티티에서 제거
   이동수단은 이제 더이상 사용하지 않음 그러나 저장여부로 사용하였다.
   그래서 is_saved 컬럼 추가하고 기존에 컬럼 삭제