### PR TITLE
feat: 알림 읽음처리 API 구현

### DIFF
--- a/tripeer/src/main/java/com/j10d207/tripeer/exception/ErrorCode.java
+++ b/tripeer/src/main/java/com/j10d207/tripeer/exception/ErrorCode.java
@@ -69,7 +69,11 @@ public enum ErrorCode {
     //Valid
     RUNTIME_EXCEPTION(HttpStatus.NOT_FOUND, "VALID-001", "예측되지 않은 오류가 발생했습니다. "),
     INVALID_ARGUMENT(HttpStatus.BAD_REQUEST, "VALID-002", "Invalid argument"),
-    INVALID_PAGE(HttpStatus.BAD_REQUEST, "VALID-003", "입력될 수 없는 페이지 값");
+    INVALID_PAGE(HttpStatus.BAD_REQUEST, "VALID-003", "입력될 수 없는 페이지 값"),
+
+    // Notification
+    NOT_FOUND_NOTI(HttpStatus.NOT_FOUND, "NOTI-001", "알림을 찾을 수 없습니다.")
+    ;
 
 
     private final HttpStatus httpStatus;	// HttpStatus

--- a/tripeer/src/main/java/com/j10d207/tripeer/noti/controller/NotificationController.java
+++ b/tripeer/src/main/java/com/j10d207/tripeer/noti/controller/NotificationController.java
@@ -3,6 +3,8 @@ package com.j10d207.tripeer.noti.controller;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -31,6 +33,7 @@ import lombok.extern.slf4j.Slf4j;
 public class NotificationController {
 
 	private final FirebaseTokenService firebaseTokenService;
+	private final NotificationService notificationService;
 	private final TestNotificationService testService;
 
 	/**
@@ -40,7 +43,8 @@ public class NotificationController {
 	 *     해당 유저의 Firebase token을 DB에 추가한다.
 	 * </p>
 	 *
-	 * @param: 	user 객체
+	 * @param user:	로그인 된 유저 객체
+	 * @param token: 저장할 Firebase token
 	 * @status: 성공시 204 NO_CONTENT
 	 * @body: 	null
 	 *
@@ -55,6 +59,31 @@ public class NotificationController {
 		return Response.of(
 			ResponseHeader.FIREBASE_ADDED.getStatus(),
 			ResponseHeader.FIREBASE_ADDED.getMessage(),
+			null
+		);
+	}
+
+	/**
+	 * @author: 김회창
+	 *
+	 * <p>
+	 *     해당 알림의 상태를 SENT 에서 READ 로 변경 한다.
+	 * </p>
+	 *
+	 * @param id: 상태를 변경할 알림의 고유 번호
+	 * @status: 성공시 204 NO_CONTENT
+	 * @body: 	null
+	 *
+	 */
+
+	@PatchMapping("/{notificationId}")
+	public Response<Void> readNotification(
+		@PathVariable("notificationId") Long id
+	) {
+		notificationService.updateStateToRead(id);
+		return Response.of(
+			ResponseHeader.NOTI_READ.getStatus(),
+			ResponseHeader.NOTI_READ.getMessage(),
 			null
 		);
 	}
@@ -107,8 +136,8 @@ public class NotificationController {
 	private enum ResponseHeader {
 
 		FIREBASE_ADDED("토큰 추가에 성공했습니다.", HttpStatus.NO_CONTENT),
-		TEST("테스트용 API입니다.", HttpStatus.NO_CONTENT)
-
+		TEST("테스트용 API입니다.", HttpStatus.NO_CONTENT),
+		NOTI_READ("읽음 처리에 성공했습니다.", HttpStatus.NO_CONTENT)
 		;
 
 		private final String message;

--- a/tripeer/src/main/java/com/j10d207/tripeer/noti/db/entity/Notification.java
+++ b/tripeer/src/main/java/com/j10d207/tripeer/noti/db/entity/Notification.java
@@ -74,4 +74,8 @@ public class Notification {
 	public void toSENT() {
 		this.state = State.SENT;
 	}
+
+	public void toREAD() {
+		this.state = State.READ;
+	}
 }

--- a/tripeer/src/main/java/com/j10d207/tripeer/noti/service/NotificationService.java
+++ b/tripeer/src/main/java/com/j10d207/tripeer/noti/service/NotificationService.java
@@ -2,12 +2,15 @@ package com.j10d207.tripeer.noti.service;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.google.firebase.FirebaseException;
 import com.google.firebase.messaging.Message;
+import com.j10d207.tripeer.exception.CustomException;
+import com.j10d207.tripeer.exception.ErrorCode;
 import com.j10d207.tripeer.noti.db.entity.FirebaseToken;
 import com.j10d207.tripeer.noti.db.entity.Notification;
 import com.j10d207.tripeer.noti.db.firebase.FirebasePublisher;
@@ -60,9 +63,20 @@ public class NotificationService {
 	}
 
 	@Transactional
-	public void updateStateToSent(final Notification task) {
-		final Notification mergedTaskEntity = em.merge(task);
-		mergedTaskEntity.toSENT();
+	public void updateStateToSent(Notification task) {
+		if (!em.contains(task)) task = em.merge(task);
+		task.toSENT();
+	}
+
+	@Transactional
+	public void updateStateToRead(final Long id) {
+		final Optional<Notification> notification = notificationRepository.findById(id);
+		notification.ifPresentOrElse(
+			Notification::toREAD,
+			() -> {
+				throw new CustomException(ErrorCode.NOT_FOUND_NOTI);
+			}
+		);
 	}
 
 


### PR DESCRIPTION
## PR 유형
어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [x] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 주요 변경사항

- 알림에 대한 상태를 READ로 변경하는 PATCH 타입 API 추가 (/api/noti/{notificationID})

## For Reviewer

- 이 후 개발할 알림 목록에서 유저 초대 알림의 경우 프론트에서 planId를 받아야한다고 하여 Invite 이벤트 객체에 planId라는 변경사항도 존재함
- DB에도 마찬가지로 notification 테이블에 targetId라는게 추가됨 
  - 사용목적은 planId와 같이 백엔드에서 조회 할 대상은 아니지만 프론트에서 필요한 경우임