### PR TITLE
fix: allowNotification 에 따른 푸시알림 조건분기 추가

### DIFF
--- a/tripeer/src/main/java/com/j10d207/tripeer/noti/service/NotificationTaskService.java
+++ b/tripeer/src/main/java/com/j10d207/tripeer/noti/service/NotificationTaskService.java
@@ -14,6 +14,7 @@ import com.j10d207.tripeer.noti.db.firebase.FirebasePublisher;
 import com.j10d207.tripeer.noti.db.firebase.MessageBody;
 import com.j10d207.tripeer.noti.db.firebase.MessageBuilder;
 import com.j10d207.tripeer.noti.db.repository.NotificationTaskRepository;
+import com.j10d207.tripeer.user.service.UserService;
 
 import jakarta.persistence.EntityManager;
 import lombok.RequiredArgsConstructor;
@@ -29,6 +30,8 @@ public class NotificationTaskService {
 	private final FirebaseTokenService firebaseTokenService;
 
 	private final FirebasePublisher firebasePublisher;
+
+	private final UserService userService;
 
 	private final EntityManager em;
 
@@ -73,6 +76,15 @@ public class NotificationTaskService {
 	public void processingMessageTask (NotificationTask task) {
 
 		if(em.contains(task)) task = em.merge(task);
+
+		final Long userId =  task.getNotification().getUserId();
+
+		final Boolean isAllow = userService.getAllowNotificationById(userId);
+
+		if (!isAllow) {
+			log.info("Not allow Notification userId: {}", userId);
+			return;
+		}
 
 		final Notification notification = task.getNotification();
 

--- a/tripeer/src/main/java/com/j10d207/tripeer/noti/service/TestNotificationService.java
+++ b/tripeer/src/main/java/com/j10d207/tripeer/noti/service/TestNotificationService.java
@@ -47,7 +47,6 @@ public class TestNotificationService {
 
 		MessageBody msgBody = MessageBuilder.getMessageBody(MessageType.TRIPEER_START, planTitle, userNickname);
 
-
 		firebaseTokens.forEach(token -> {
 			try {
 				firebasePublisher.sendFirebaseMessage(MessageBuilder.toFirebaseMessage(msgBody, token.getToken()));

--- a/tripeer/src/main/java/com/j10d207/tripeer/user/service/UserService.java
+++ b/tripeer/src/main/java/com/j10d207/tripeer/user/service/UserService.java
@@ -10,6 +10,7 @@ import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
+import java.util.Map;
 
 // access 토큰 재발급
 public interface UserService {
@@ -41,5 +42,8 @@ public interface UserService {
     public String getSuper2(HttpServletResponse response, long userId);
     // 알람 설정 변경
     public String changeNoti(long userId, NotiReq notiReq);
+
+    // 해당 하는 유저의 notification allow 상태 확인
+   Boolean getAllowNotificationById(final Long userIds);
 
 }

--- a/tripeer/src/main/java/com/j10d207/tripeer/user/service/UserServiceImpl.java
+++ b/tripeer/src/main/java/com/j10d207/tripeer/user/service/UserServiceImpl.java
@@ -27,7 +27,9 @@ import org.springframework.web.multipart.MultipartFile;
 
 import java.util.Date;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 @Service
 @Slf4j
@@ -232,5 +234,11 @@ public class UserServiceImpl implements UserService{
 
         return cookie;
     }
+
+    // 해당 하는 유저의 notification allow 상태 확인
+    public Boolean getAllowNotificationById(final Long userId) {
+        final Optional<UserEntity> user = userRepository.findById(userId);
+		return user.map(UserEntity::isAllowNotifications).orElse(false);
+	}
 
 }


### PR DESCRIPTION
## PR 유형
어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 주요 변경사항

- user에 allowNotification 값에 따른 푸시알림 조건분기 추가
  - 푸시알림만 안나가는것일 뿐, 실제 알림목록 조회시에는 조회가능함
  - 만약 스케쥴링 된 당시에는 유저가 알림을 허용했더라도, 나중에 허용을 해제하면 푸시알림 역시 발생하지 않도록 변경함

- UserService에 id를 받아서 해당 유저의 allowNotification 여부를 반환하는 메소드 추가
