### PR TITLE
fix: invite 이벤트 dto 에 planTitle null 이슈 해결

### DIFF
--- a/tripeer/src/main/java/com/j10d207/tripeer/plan/service/PlanServiceImpl.java
+++ b/tripeer/src/main/java/com/j10d207/tripeer/plan/service/PlanServiceImpl.java
@@ -276,7 +276,8 @@ public class PlanServiceImpl implements PlanService {
         UserEntity user = userRepository.findByUserId(coworkerInvitedReq.getUserId());
 
         // 플랜 초대 알림
-        PlanEntity coworkerPlan = coworkerEntity.getPlan();
+        PlanEntity coworkerPlan = planRepository.findByPlanId(coworkerInvitedReq.getPlanId());
+
         publisher.publishEvent(InviteCoworkerEvent.builder()
             .planTitle(coworkerPlan.getTitle())
             .invitedCoworker(new CoworkerDto(user.getUserId(),user.getNickname()))


### PR DESCRIPTION
## PR 유형
어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 주요 변경사항

- planServiceImpl 에 invitePlan 메소드에 이벤트 객체 호출 때, planTitle이 null 인 이슈 해결
   - 원인: 기존의 save 한 coworkerEntity는 planEntity를 id만 갖고있기 때문에 한번 호출하고 나서 영속화 해야 title 불러올 수 있음 
