### PR TITLE
fix : 별점 평균 로직 변경, 히스토리 디테일 조회 로직 수정

### DIFF
--- a/tripeer/src/main/java/com/j10d207/tripeer/exception/ErrorCode.java
+++ b/tripeer/src/main/java/com/j10d207/tripeer/exception/ErrorCode.java
@@ -25,6 +25,7 @@ public enum ErrorCode {
     EXPIRED_JWT(HttpStatus.UNAUTHORIZED, "ACCOUNT-008", "토큰이 만료되었습니다."),
     NONE_WISHLIST(HttpStatus.BAD_REQUEST, "ACCOUNT-009", "찜목록에 없는 장소입니다"),
     HAS_WISHLIST(HttpStatus.BAD_REQUEST, "ACCOUNT-009", "이미 찜목록에 등록된 장소입니다"),
+    DONT_HAVE_PERMISSION(HttpStatus.FORBIDDEN, "ACCOUNT-010", "작성자가 아니거나 권한이 없습니다"),
 
     // plan
     HAS_BUCKET(HttpStatus.BAD_REQUEST, "PLAN-001", "이미 등록된 장소입니다."),
@@ -50,6 +51,7 @@ public enum ErrorCode {
     UNDEFINED_TYPE(HttpStatus.NOT_FOUND, "PLACE-004", "정의되지 않은 타입입니다."),
     BLOG_SEARCH_ERROR(HttpStatus.BAD_REQUEST, "PLACE-005", "블로그 검색 중 마지막 페이지를 넘었거나 오류가 발생했습니다."),
     FOUND_SPOT(HttpStatus.BAD_REQUEST, "PLACE-006", "이미 서비스에 존재하는 장소입니다."),
+    REVIEW_NOT_FOUND(HttpStatus.NOT_FOUND, "PLACE-007", "리뷰를 찾을 수 없습니다."),
 
     //root
     NOT_FOUND_ROOT(HttpStatus.BAD_REQUEST, "ROOT-001", "대중교통 수단이 없습니다."),

--- a/tripeer/src/main/java/com/j10d207/tripeer/history/dto/res/HistoryDayRes.java
+++ b/tripeer/src/main/java/com/j10d207/tripeer/history/dto/res/HistoryDayRes.java
@@ -2,6 +2,7 @@ package com.j10d207.tripeer.history.dto.res;
 
 import java.util.List;
 
+import com.j10d207.tripeer.place.db.entity.SpotReviewEntity;
 import com.j10d207.tripeer.plan.db.entity.PlanDayEntity;
 import com.j10d207.tripeer.user.db.entity.UserEntity;
 
@@ -16,11 +17,12 @@ public class HistoryDayRes {
 	// 각 날짜 별로 어느 관광지에 갔었는지의 리스트
 	private List<HistorySpotRes> planDetailList;
 
-	public static HistoryDayRes from(PlanDayEntity planDayEntity, UserEntity userEntity) {
+	public static HistoryDayRes from(PlanDayEntity planDayEntity, List<Integer> reviewIdList) {
 		return HistoryDayRes.builder()
 			.planDayId(planDayEntity.getPlanDayId())
 			.date(planDayEntity.getDay().toString())
-			.planDetailList(planDayEntity.getPlanDetailList().stream().map(el -> HistorySpotRes.from(el, userEntity)).toList())
+			.planDetailList(planDayEntity.getPlanDetailList().stream().map(el ->
+				HistorySpotRes.from(el, reviewIdList.contains(el.getSpotInfo().getSpotInfoId()))).toList())
 			.build();
 	}
 

--- a/tripeer/src/main/java/com/j10d207/tripeer/history/dto/res/HistoryDetailRes.java
+++ b/tripeer/src/main/java/com/j10d207/tripeer/history/dto/res/HistoryDetailRes.java
@@ -24,11 +24,11 @@ public class HistoryDetailRes {
 	// 해당 여행의 장소를 리스트로 반환 ex) {cityId : 12, townId : 123}
 	private List<Map<String, Integer>> cityIdTownIdList;
 
-	public static HistoryDetailRes from(PlanEntity planEntity, UserEntity userEntity) {
+	public static HistoryDetailRes from(PlanEntity planEntity, List<Integer> reviewIdList) {
 		return HistoryDetailRes.builder()
 			.planId(planEntity.getPlanId())
 			.diaryDetail(PlanInfoRes.from(planEntity))
-			.diaryDayList(planEntity.getPlanDayList().stream().map(el -> HistoryDayRes.from(el,userEntity)).toList())
+			.diaryDayList(planEntity.getPlanDayList().stream().map(el -> HistoryDayRes.from(el,reviewIdList)).toList())
 			.cityIdTownIdList(makeCityIdTownIdList(planEntity))
 			.build();
 	}

--- a/tripeer/src/main/java/com/j10d207/tripeer/history/dto/res/HistorySpotRes.java
+++ b/tripeer/src/main/java/com/j10d207/tripeer/history/dto/res/HistorySpotRes.java
@@ -1,5 +1,7 @@
 package com.j10d207.tripeer.history.dto.res;
 
+import java.util.List;
+
 import com.j10d207.tripeer.place.db.ContentTypeEnum;
 import com.j10d207.tripeer.place.db.entity.SpotReviewEntity;
 import com.j10d207.tripeer.plan.db.entity.PlanDetailEntity;
@@ -25,7 +27,7 @@ public class HistorySpotRes {
 	private int step;
 	private int cost;
 
-	public static HistorySpotRes from(PlanDetailEntity planDetailEntity, UserEntity userEntity) {
+	public static HistorySpotRes from(PlanDetailEntity planDetailEntity, Boolean isWriteReview ) {
 		return HistorySpotRes.builder()
 			.planDetailId(planDetailEntity.getPlanDetailId())
 			.spotId(planDetailEntity.getSpotInfo().getSpotInfoId())
@@ -36,7 +38,7 @@ public class HistorySpotRes {
 			.latitude(planDetailEntity.getSpotInfo().getLatitude())
 			.longitude(planDetailEntity.getSpotInfo().getLongitude())
 			.starPointAvg(planDetailEntity.getSpotInfo().getStarPointAvg())
-			// .isWriteReview(planDetailEntity.getSpotInfo().getSpotReviewList().stream().map(SpotReviewEntity::getUser).anyMatch(userEntity::equals))
+			.isWriteReview(isWriteReview)
 			.day(planDetailEntity.getDay())
 			.step(planDetailEntity.getStep())
 			.cost(planDetailEntity.getCost())

--- a/tripeer/src/main/java/com/j10d207/tripeer/history/dto/res/HistorySpotRes.java
+++ b/tripeer/src/main/java/com/j10d207/tripeer/history/dto/res/HistorySpotRes.java
@@ -35,9 +35,8 @@ public class HistorySpotRes {
 			.address(planDetailEntity.getSpotInfo().getAddr1())
 			.latitude(planDetailEntity.getSpotInfo().getLatitude())
 			.longitude(planDetailEntity.getSpotInfo().getLongitude())
-			.starPointAvg(planDetailEntity.getSpotInfo().getSpotReviewList().stream().mapToDouble(
-				SpotReviewEntity::getStarPoint).average().orElse(0.0))
-			.isWriteReview(planDetailEntity.getSpotInfo().getSpotReviewList().stream().map(SpotReviewEntity::getUser).anyMatch(userEntity::equals))
+			.starPointAvg(planDetailEntity.getSpotInfo().getStarPointAvg())
+			// .isWriteReview(planDetailEntity.getSpotInfo().getSpotReviewList().stream().map(SpotReviewEntity::getUser).anyMatch(userEntity::equals))
 			.day(planDetailEntity.getDay())
 			.step(planDetailEntity.getStep())
 			.cost(planDetailEntity.getCost())

--- a/tripeer/src/main/java/com/j10d207/tripeer/history/service/HistoryServiceImpl.java
+++ b/tripeer/src/main/java/com/j10d207/tripeer/history/service/HistoryServiceImpl.java
@@ -23,6 +23,7 @@ import com.j10d207.tripeer.history.dto.req.PlanSaveReq;
 import com.j10d207.tripeer.history.dto.res.CostRes;
 import com.j10d207.tripeer.history.dto.res.HistoryDetailRes;
 import com.j10d207.tripeer.history.dto.res.PlanInfoRes;
+import com.j10d207.tripeer.place.db.repository.SpotReviewRepository;
 import com.j10d207.tripeer.plan.db.entity.PlanDayEntity;
 import com.j10d207.tripeer.plan.db.entity.PlanDetailEntity;
 import com.j10d207.tripeer.plan.db.entity.PlanEntity;
@@ -47,6 +48,7 @@ public class HistoryServiceImpl implements HistoryService {
 	private final PlanDetailRepository planDetailRepository;
 	private final PlanDayRepository planDayRepository;
 	private final WebClient webClient;
+	private final SpotReviewRepository spotReviewRepository;
 	private final UserRepository userRepository;
 
 	ObjectMapper objectMapper = new ObjectMapper();
@@ -71,10 +73,10 @@ public class HistoryServiceImpl implements HistoryService {
 	}
 
 	public HistoryDetailRes getHistoryDetail(long planId, long userId) {
-		UserEntity user = userRepository.findByUserId(userId);
-		PlanEntity plan = Optional.ofNullable(planRepository.findByPlanId(planId))
+		UserEntity user = userRepository.findById(userId).orElseThrow(() ->new CustomException(ErrorCode.USER_NOT_FOUND));
+		PlanEntity plan = Optional.ofNullable(planRepository.findByPlanForHistory(planId))
 			.orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_PLAN));
-		return HistoryDetailRes.from(plan, user);
+		return HistoryDetailRes.from(plan, spotReviewRepository.findSpotInfoIdsByUser(user));
 	}
 
 	public String revokeHistoryDetail(long planId) {

--- a/tripeer/src/main/java/com/j10d207/tripeer/place/controller/PlaceController.java
+++ b/tripeer/src/main/java/com/j10d207/tripeer/place/controller/PlaceController.java
@@ -87,6 +87,11 @@ public class PlaceController {
         reviewService.saveReview(user.getUserId(), reviewReq, multipartFiles);
         return Response.of(HttpStatus.OK, "리뷰 작성 완료", null);
     }
+    @DeleteMapping(value = "review/{spotReviewId}")
+    public Response<?> createReview(@AuthenticationPrincipal CustomOAuth2User user, @PathVariable long spotReviewId) {
+        reviewService.deleteReview(user.getUserId(), spotReviewId);
+        return Response.of(HttpStatus.NO_CONTENT, "리뷰 작성 완료", null);
+    }
 
     // 홈화면 추천 api
     @GetMapping("/recommend/home")

--- a/tripeer/src/main/java/com/j10d207/tripeer/place/db/entity/SpotInfoEntity.java
+++ b/tripeer/src/main/java/com/j10d207/tripeer/place/db/entity/SpotInfoEntity.java
@@ -60,6 +60,9 @@ public class SpotInfoEntity {
 	private double longitude;
 	//받은 DB에 있었는데 뭔지 모르겠습니다.
 	private String mlevel;
+	// 평균 별점을 들고오기위해 spotReviewList를 받는 것은 비효율적인 것 같아서 추가
+	// 리뷰 작성및 삭제때 마다 업데이트해주는 식으로 구현해놓음
+	private double starPointAvg;
 
 	@OneToMany(fetch = FetchType.LAZY)
 	@JoinColumns({@JoinColumn(name = "SPOT_INFO_ID")})

--- a/tripeer/src/main/java/com/j10d207/tripeer/place/db/entity/SpotInfoEntity.java
+++ b/tripeer/src/main/java/com/j10d207/tripeer/place/db/entity/SpotInfoEntity.java
@@ -62,7 +62,19 @@ public class SpotInfoEntity {
 	private String mlevel;
 	// 평균 별점을 들고오기위해 spotReviewList를 받는 것은 비효율적인 것 같아서 추가
 	// 리뷰 작성및 삭제때 마다 업데이트해주는 식으로 구현해놓음
-	private double starPointAvg;
+	@Setter
+	private double starSum;
+	@Setter
+	private Integer starCount;
+
+	// 별점 평균은 소수점 첫째자리까지만
+	public double getStarPointAvg() {
+		if (starSum == 0) {
+			return 0.0; // starSum가 0이면 기본값 반환
+		}
+		double starPoint = starSum / starCount;
+		return Math.round(starPoint * 10) / 10.0;
+	}
 
 	@OneToMany(fetch = FetchType.LAZY)
 	@JoinColumns({@JoinColumn(name = "SPOT_INFO_ID")})

--- a/tripeer/src/main/java/com/j10d207/tripeer/place/db/repository/SpotReviewRepository.java
+++ b/tripeer/src/main/java/com/j10d207/tripeer/place/db/repository/SpotReviewRepository.java
@@ -1,6 +1,8 @@
 package com.j10d207.tripeer.place.db.repository;
 
 import com.j10d207.tripeer.place.db.entity.SpotReviewEntity;
+import com.j10d207.tripeer.user.db.entity.UserEntity;
+
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -18,4 +20,7 @@ public interface SpotReviewRepository extends JpaRepository<SpotReviewEntity, Lo
 //    Optional<Double> findAverageStarPointBySpotInfo_SpotInfoId(long spotInfoId);
     @Query(value = "SELECT AVG(star_point) FROM tripeer.spot_review WHERE spot_info_id = :spotInfoId", nativeQuery = true)
     Optional<Double> findAverageStarPointBySpotInfoId(@Param("spotInfoId") int spotInfoId);
+
+    @Query("SELECT sr.spotInfo.spotInfoId FROM spot_review sr WHERE sr.user = :user")
+    List<Integer> findSpotInfoIdsByUser(UserEntity user);
 }

--- a/tripeer/src/main/java/com/j10d207/tripeer/place/dto/res/SpotDTO.java
+++ b/tripeer/src/main/java/com/j10d207/tripeer/place/dto/res/SpotDTO.java
@@ -98,8 +98,7 @@ public class SpotDTO {
                     .address(spotInfoEntity.getAddr1())
                     .contentType(ContentTypeEnum.getNameByCode(spotInfoEntity.getContentTypeId()))
                     .spotName(spotInfoEntity.getTitle())
-                    .starPointAvg(spotInfoEntity.getSpotReviewList().stream().mapToDouble(
-						SpotReviewEntity::getStarPoint).average().orElse(0.0))
+                    .starPointAvg(spotInfoEntity.getStarPointAvg())
                     .latitude(spotInfoEntity.getLatitude())
                     .longitude(spotInfoEntity.getLongitude())
                     .isWishlist(isWishlist)

--- a/tripeer/src/main/java/com/j10d207/tripeer/place/dto/res/SpotDetailPageDto.java
+++ b/tripeer/src/main/java/com/j10d207/tripeer/place/dto/res/SpotDetailPageDto.java
@@ -57,6 +57,7 @@ public class SpotDetailPageDto {
                 .latitude(spotInfoEntity.getLatitude())
                 .longitude(spotInfoEntity.getLongitude())
                 .addr1(spotInfoEntity.getAddr1())
+                .starPointAvg(spotInfoEntity.getStarPointAvg())
                 .build();
     }
 }

--- a/tripeer/src/main/java/com/j10d207/tripeer/place/service/ReviewService.java
+++ b/tripeer/src/main/java/com/j10d207/tripeer/place/service/ReviewService.java
@@ -8,4 +8,5 @@ import java.util.List;
 public interface ReviewService {
 
     public void saveReview(long userId, ReviewReq reviewReq, List<MultipartFile> multipartFileList);
+    public void deleteReview(long userId, long spotReviewId);
 }

--- a/tripeer/src/main/java/com/j10d207/tripeer/place/service/ReviewServiceImpl.java
+++ b/tripeer/src/main/java/com/j10d207/tripeer/place/service/ReviewServiceImpl.java
@@ -2,7 +2,9 @@ package com.j10d207.tripeer.place.service;
 
 import com.j10d207.tripeer.exception.CustomException;
 import com.j10d207.tripeer.exception.ErrorCode;
+import com.j10d207.tripeer.place.db.entity.SpotInfoEntity;
 import com.j10d207.tripeer.place.db.entity.SpotReviewEntity;
+import com.j10d207.tripeer.place.db.repository.SpotInfoRepository;
 import com.j10d207.tripeer.place.db.repository.SpotReviewRepository;
 import com.j10d207.tripeer.place.dto.req.ReviewReq;
 import com.j10d207.tripeer.s3.dto.FileInfoDto;
@@ -11,26 +13,29 @@ import com.j10d207.tripeer.s3.service.S3Service;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 @Service
 @Slf4j
 @RequiredArgsConstructor
 public class ReviewServiceImpl implements ReviewService {
 
+    private final SpotInfoRepository spotInfoRepository;
     private final SpotReviewRepository spotReviewRepository;
     private final S3Service s3Service;
 
     @Override
+    @Transactional
     public void saveReview(long userId, ReviewReq reviewReq, List<MultipartFile> multipartFileList) {
 
         if (reviewReq.getSpotReviewId() > 0 ) {
             s3Service.deleteFile("https://tripeer207.s3.ap-northeast-2.amazonaws.com/Review/" + reviewReq.getSpotReviewId(), S3Option.reviewDelete);
         }
-
         SpotReviewEntity spotReviewEntity = spotReviewRepository.save(SpotReviewEntity.ofReviewReq(reviewReq, userId, multipartFileList));
         List<String> uploadURLList = new ArrayList<>();
         if (multipartFileList != null) {
@@ -40,8 +45,24 @@ public class ReviewServiceImpl implements ReviewService {
                 uploadURLList.add(s3Service.fileUpload(fileInfoDto));
             }
         }
-
+        SpotInfoEntity spotInfo = spotInfoRepository.findBySpotInfoId(reviewReq.getSpotInfoId());
+        spotInfo.setStarSum(spotInfo.getStarSum() + reviewReq.getStarPoint());
+        spotInfo.setStarCount(spotInfo.getStarCount() + 1);
+        spotInfoRepository.save(spotInfo);
         spotReviewEntity.setImages(uploadURLList);
         spotReviewRepository.save(spotReviewEntity);
+    }
+
+    @Override
+    @Transactional
+    public void deleteReview(long userId, long spotReviewId) {
+        s3Service.deleteFile("https://tripeer207.s3.ap-northeast-2.amazonaws.com/Review/" + spotReviewId, S3Option.reviewDelete);
+        SpotReviewEntity spotReview = spotReviewRepository.findById(spotReviewId).orElseThrow(()->new CustomException(ErrorCode.REVIEW_NOT_FOUND));
+        if (spotReview.getUser().getUserId() != userId) throw new CustomException(ErrorCode.DONT_HAVE_PERMISSION);
+        SpotInfoEntity spotInfo = spotReview.getSpotInfo();
+        spotInfo.setStarCount(spotInfo.getStarCount() - 1);
+        spotInfo.setStarSum(spotInfo.getStarSum() - spotReview.getStarPoint());
+        spotReviewRepository.save(spotReview);
+        spotReviewRepository.delete(spotReview);
     }
 }

--- a/tripeer/src/main/java/com/j10d207/tripeer/place/service/SpotServiceImpl.java
+++ b/tripeer/src/main/java/com/j10d207/tripeer/place/service/SpotServiceImpl.java
@@ -65,12 +65,6 @@ public class SpotServiceImpl implements SpotService{
         Set<Integer> wishList = wishListRepository.findAllSpotInfoIdsByUserId(userId);
         spotDetailPageDto.setLike(wishList.contains(spotInfoId));
         spotDetailPageDto.setOverview(spotDescriptionRepository.findBySpotInfo(spotInfoEntity).getOverview());
-
-        spotReviewRepository.findAverageStarPointBySpotInfoId(spotInfoEntity.getSpotInfoId())
-                .map(starPoint -> Math.round(starPoint * 10) / 10.0)
-                    .ifPresentOrElse(spotDetailPageDto::setStarPointAvg,
-                            () -> spotDetailPageDto.setStarPointAvg(0)
-                    );
         spotDetailPageDto.setAdditionalInfo(AdditionalDto.from(additionalBaseRepository.findBySpotInfo(spotInfoEntity)));
 
         SpotCollectionEntity spotCollection = spotCollectionRepository.findBySpotInfoId(spotInfoEntity.getSpotInfoId());

--- a/tripeer/src/main/java/com/j10d207/tripeer/plan/db/entity/PlanDetailEntity.java
+++ b/tripeer/src/main/java/com/j10d207/tripeer/plan/db/entity/PlanDetailEntity.java
@@ -37,7 +37,7 @@ public class PlanDetailEntity {
 	@JoinColumn(name = "PLAN_DAY_ID")
 	private PlanDayEntity planDay;
 
-	@ManyToOne(fetch = FetchType.LAZY)
+	@ManyToOne(fetch = FetchType.EAGER)
 	@JoinColumn(name = "SPOT_INFO_ID")
 	private SpotInfoEntity spotInfo;
 

--- a/tripeer/src/main/java/com/j10d207/tripeer/plan/db/entity/PlanEntity.java
+++ b/tripeer/src/main/java/com/j10d207/tripeer/plan/db/entity/PlanEntity.java
@@ -11,6 +11,7 @@ import jakarta.persistence.Id;
 import java.time.LocalDate;
 import java.time.ZoneId;
 import java.util.List;
+import java.util.Set;
 
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.OneToMany;
@@ -41,7 +42,7 @@ public class PlanEntity {
 
 	@OneToMany(fetch = FetchType.LAZY)
 	@JoinColumn(name = "PLAN_ID")
-	List<PlanDayEntity> planDayList;
+	Set<PlanDayEntity> planDayList;
 
 	@OneToMany(fetch = FetchType.LAZY)
 	@JoinColumn(name = "PLAN_ID")

--- a/tripeer/src/main/java/com/j10d207/tripeer/plan/db/repository/PlanRepository.java
+++ b/tripeer/src/main/java/com/j10d207/tripeer/plan/db/repository/PlanRepository.java
@@ -16,4 +16,12 @@ public interface PlanRepository extends JpaRepository<PlanEntity, Long> {
 
     @Query("SELECT p.planId FROM plan p where p.isSaved = false AND p.endDate < :today ")
     List<Long> findAllWithUnsavedAndPastEndDate(@Param("today") LocalDate today);
+
+    @Query("SELECT p FROM plan p " +
+        "LEFT JOIN FETCH p.planDayList pd " +
+        "LEFT JOIN FETCH pd.planDetailList pdl " +
+        "LEFT JOIN FETCH pdl.spotInfo si " +
+        "WHERE p.planId = :planId")
+    PlanEntity findByPlanForHistory(@Param("planId") long planId);
 }
+

--- a/tripeer/src/main/java/com/j10d207/tripeer/plan/dto/res/SpotSearchResDTO.java
+++ b/tripeer/src/main/java/com/j10d207/tripeer/plan/dto/res/SpotSearchResDTO.java
@@ -42,8 +42,7 @@ public class SpotSearchResDTO {
                     .title(wishList.getSpotInfo().getTitle())
                     .contentType(ContentTypeEnum.getNameByCode(wishList.getSpotInfo().getContentTypeId()))
                     .addr(wishList.getSpotInfo().getAddr1())
-                    .starPointAvg(wishList.getSpotInfo().getSpotReviewList().stream().mapToDouble(
-                            SpotReviewEntity::getStarPoint).average().orElse(0.0))
+                    .starPointAvg(wishList.getSpotInfo().getStarPointAvg())
                     .latitude(wishList.getSpotInfo().getLatitude())
                     .longitude(wishList.getSpotInfo().getLongitude())
                     .img(wishList.getSpotInfo().getFirstImage())
@@ -64,8 +63,7 @@ public class SpotSearchResDTO {
                     .title(spotInfo.getTitle())
                     .contentType(ContentTypeEnum.getMajorNameByCode(spotInfo.getContentTypeId()))
                     .addr(spotInfo.getAddr1())
-                    .starPointAvg(spotInfo.getSpotReviewList().stream().mapToDouble(
-                            SpotReviewEntity::getStarPoint).average().orElse(0.0))
+                    .starPointAvg(spotInfo.getStarPointAvg())
                     .latitude(spotInfo.getLatitude())
                     .longitude(spotInfo.getLongitude())
                     .img(img)

--- a/tripeer/src/main/java/com/j10d207/tripeer/plan/dto/res/SpotSearchResDTO.java
+++ b/tripeer/src/main/java/com/j10d207/tripeer/plan/dto/res/SpotSearchResDTO.java
@@ -35,6 +35,8 @@ public class SpotSearchResDTO {
         private boolean isWishlist;
         private boolean isSpot;
 
+
+
         public static SearchResult fromWishListEntity(WishListEntity wishList, boolean isSpot) {
 
             return SearchResult.builder()

--- a/tripeer/src/main/java/com/j10d207/tripeer/user/dto/res/UserDTO.java
+++ b/tripeer/src/main/java/com/j10d207/tripeer/user/dto/res/UserDTO.java
@@ -82,6 +82,7 @@ public class UserDTO {
                     .latitude(wishListEntity.getSpotInfo().getLatitude())
                     .longitude(wishListEntity.getSpotInfo().getLongitude())
                     .img(wishListEntity.getSpotInfo().getFirstImage())
+                    .starPointAvg(wishListEntity.getSpotInfo().getStarPointAvg())
                     .isLike(true)
                     .build();
         }

--- a/tripeer/src/main/java/com/j10d207/tripeer/user/service/UserServiceImpl.java
+++ b/tripeer/src/main/java/com/j10d207/tripeer/user/service/UserServiceImpl.java
@@ -129,14 +129,6 @@ public class UserServiceImpl implements UserService{
     public List<UserDTO.Wishlist> getMyWishlist(long userId) {
         List<WishListEntity> wishListEntityList = wishListRepository.findByUser_UserId(userId);
         List<UserDTO.Wishlist> wishlistList = wishListEntityList.stream().map(UserDTO.Wishlist::ofEntity).toList();
-        for ( UserDTO.Wishlist wishlist : wishlistList) {
-            Optional<Double> starPoint = spotReviewRepository.findAverageStarPointBySpotInfoId(wishlist.getSpotInfoId());
-            if(starPoint.isPresent()) {
-                wishlist.setStarPointAvg(Math.round(starPoint.get()*10)/10.0);
-            } else {
-                wishlist.setStarPointAvg(0);
-            }
-        }
         return wishlistList;
     }
 


### PR DESCRIPTION
## PR 유형
어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 주요 변경사항

- 별점 평균은 검색, 추천, 다이러리 등 spot을 사용하는 많은 곳에서 필요로한다
  그런 별점을 매번 리뷰테이블에서 계산해서 들고오는 것은 비효율적이라고 생각해서
  리뷰 생성과 삭제시에 별점을 미리 업데이트하고 별점 평균이 필요할때는 업데이트된 값을 들고오게 바꿈

- 리뷰 삭제 로직 구현

- 히스토리 디테일 조회시 모든 spot에 대한 리뷰작성여부를 하나하나 계산하는 것이 아니라 유저의 리뷰의 spotIdList를 활용하는 방식으로 수정
  그리고 히스토리 디테일 조회시 필요할 정보를 join해서 미리 들고 오도록 수정
