### PR TITLE
fix : 히스토리 디테일 dto에 spotReviewId 추가

### DIFF
--- a/tripeer/src/main/java/com/j10d207/tripeer/history/dto/res/HistoryDayRes.java
+++ b/tripeer/src/main/java/com/j10d207/tripeer/history/dto/res/HistoryDayRes.java
@@ -1,6 +1,7 @@
 package com.j10d207.tripeer.history.dto.res;
 
 import java.util.List;
+import java.util.Map;
 
 import com.j10d207.tripeer.place.db.entity.SpotReviewEntity;
 import com.j10d207.tripeer.plan.db.entity.PlanDayEntity;
@@ -17,12 +18,13 @@ public class HistoryDayRes {
 	// 각 날짜 별로 어느 관광지에 갔었는지의 리스트
 	private List<HistorySpotRes> planDetailList;
 
-	public static HistoryDayRes from(PlanDayEntity planDayEntity, List<Integer> reviewIdList) {
+	public static HistoryDayRes from(PlanDayEntity planDayEntity, Map<Integer, Long> reviewIdList) {
 		return HistoryDayRes.builder()
 			.planDayId(planDayEntity.getPlanDayId())
 			.date(planDayEntity.getDay().toString())
 			.planDetailList(planDayEntity.getPlanDetailList().stream().map(el ->
-				HistorySpotRes.from(el, reviewIdList.contains(el.getSpotInfo().getSpotInfoId()))).toList())
+				HistorySpotRes.from(el, reviewIdList.containsKey(el.getSpotInfo().getSpotInfoId()),
+					reviewIdList.getOrDefault(el.getSpotInfo().getSpotInfoId(), null))).toList())
 			.build();
 	}
 

--- a/tripeer/src/main/java/com/j10d207/tripeer/history/dto/res/HistoryDetailRes.java
+++ b/tripeer/src/main/java/com/j10d207/tripeer/history/dto/res/HistoryDetailRes.java
@@ -24,7 +24,7 @@ public class HistoryDetailRes {
 	// 해당 여행의 장소를 리스트로 반환 ex) {cityId : 12, townId : 123}
 	private List<Map<String, Integer>> cityIdTownIdList;
 
-	public static HistoryDetailRes from(PlanEntity planEntity, List<Integer> reviewIdList) {
+	public static HistoryDetailRes from(PlanEntity planEntity, Map<Integer, Long> reviewIdList) {
 		return HistoryDetailRes.builder()
 			.planId(planEntity.getPlanId())
 			.diaryDetail(PlanInfoRes.from(planEntity))

--- a/tripeer/src/main/java/com/j10d207/tripeer/history/dto/res/HistorySpotRes.java
+++ b/tripeer/src/main/java/com/j10d207/tripeer/history/dto/res/HistorySpotRes.java
@@ -1,11 +1,7 @@
 package com.j10d207.tripeer.history.dto.res;
 
-import java.util.List;
-
 import com.j10d207.tripeer.place.db.ContentTypeEnum;
-import com.j10d207.tripeer.place.db.entity.SpotReviewEntity;
 import com.j10d207.tripeer.plan.db.entity.PlanDetailEntity;
-import com.j10d207.tripeer.user.db.entity.UserEntity;
 
 import lombok.Builder;
 import lombok.Getter;
@@ -23,11 +19,12 @@ public class HistorySpotRes {
 	private Double longitude;
 	private Double starPointAvg;
 	private boolean isWriteReview;
+	private long spotReviewId;
 	private int day;
 	private int step;
 	private int cost;
 
-	public static HistorySpotRes from(PlanDetailEntity planDetailEntity, Boolean isWriteReview ) {
+	public static HistorySpotRes from(PlanDetailEntity planDetailEntity, Boolean isWriteReview, Long spotReviewId) {
 		return HistorySpotRes.builder()
 			.planDetailId(planDetailEntity.getPlanDetailId())
 			.spotId(planDetailEntity.getSpotInfo().getSpotInfoId())
@@ -39,6 +36,7 @@ public class HistorySpotRes {
 			.longitude(planDetailEntity.getSpotInfo().getLongitude())
 			.starPointAvg(planDetailEntity.getSpotInfo().getStarPointAvg())
 			.isWriteReview(isWriteReview)
+			.spotReviewId(spotReviewId)
 			.day(planDetailEntity.getDay())
 			.step(planDetailEntity.getStep())
 			.cost(planDetailEntity.getCost())

--- a/tripeer/src/main/java/com/j10d207/tripeer/place/controller/PlaceController.java
+++ b/tripeer/src/main/java/com/j10d207/tripeer/place/controller/PlaceController.java
@@ -87,10 +87,11 @@ public class PlaceController {
         reviewService.saveReview(user.getUserId(), reviewReq, multipartFiles);
         return Response.of(HttpStatus.OK, "리뷰 작성 완료", null);
     }
+
     @DeleteMapping(value = "review/{spotReviewId}")
     public Response<?> createReview(@AuthenticationPrincipal CustomOAuth2User user, @PathVariable long spotReviewId) {
         reviewService.deleteReview(user.getUserId(), spotReviewId);
-        return Response.of(HttpStatus.NO_CONTENT, "리뷰 작성 완료", null);
+        return Response.of(HttpStatus.NO_CONTENT, "리뷰 삭제 완료", null);
     }
 
     // 홈화면 추천 api

--- a/tripeer/src/main/java/com/j10d207/tripeer/place/db/repository/SpotReviewRepository.java
+++ b/tripeer/src/main/java/com/j10d207/tripeer/place/db/repository/SpotReviewRepository.java
@@ -22,5 +22,5 @@ public interface SpotReviewRepository extends JpaRepository<SpotReviewEntity, Lo
     Optional<Double> findAverageStarPointBySpotInfoId(@Param("spotInfoId") int spotInfoId);
 
     @Query("SELECT sr.spotInfo.spotInfoId FROM spot_review sr WHERE sr.user = :user")
-    List<Integer> findSpotInfoIdsByUser(UserEntity user);
+    List<SpotReviewEntity> findSpotInfoIdsByUser(UserEntity user);
 }

--- a/tripeer/src/main/java/com/j10d207/tripeer/plan/db/repository/PlanRepository.java
+++ b/tripeer/src/main/java/com/j10d207/tripeer/plan/db/repository/PlanRepository.java
@@ -14,7 +14,7 @@ public interface PlanRepository extends JpaRepository<PlanEntity, Long> {
 
     PlanEntity findByPlanId(long planId);
 
-    @Query("SELECT p.planId FROM plan p where p.isSaved = false AND p.endDate < :today ")
+    @Query("SELECT p.planId FROM plan p where p.isSaved = false AND p.endDate < :today AND p.planId > 350 ")
     List<Long> findAllWithUnsavedAndPastEndDate(@Param("today") LocalDate today);
 
     @Query("SELECT p FROM plan p " +
@@ -23,5 +23,10 @@ public interface PlanRepository extends JpaRepository<PlanEntity, Long> {
         "LEFT JOIN FETCH pdl.spotInfo si " +
         "WHERE p.planId = :planId")
     PlanEntity findByPlanForHistory(@Param("planId") long planId);
+
+    @Query("SELECT p FROM plan p " +
+        "LEFT JOIN coworker c ON p.planId = c.plan.planId " +
+        "WHERE c.coworkerId IS NULL")
+    List<PlanEntity> findUnusedPlans();
 }
 

--- a/tripeer/src/main/java/com/j10d207/tripeer/user/db/repository/CoworkerRepository.java
+++ b/tripeer/src/main/java/com/j10d207/tripeer/user/db/repository/CoworkerRepository.java
@@ -29,4 +29,9 @@ public interface CoworkerRepository  extends JpaRepository<CoworkerEntity, Long>
 
     List<CoworkerEntity> findByUser_UserIdAndPlan_EndDateAfter(long user_userId, LocalDate startDate);
     List<CoworkerEntity> findByUser_UserIdAndPlan_EndDateAfterAndRole(long user_userId, LocalDate startDate, String role);
+
+    @Query("SELECT c FROM coworker c " +
+        "JOIN c.plan p " +
+        "WHERE p.endDate < CURRENT_DATE AND p.isSaved = false")
+    List<CoworkerEntity> findExpiredAndUnsavedCoworkers();
 }


### PR DESCRIPTION
## PR 유형
어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 주요 변경사항

- 히스토리 디테일 dto에 spotReviewId 추가
-  플랜 저장 중 ydoc 탬플릿이 없어 저장이 안 되는 플랜이 존재해 Transactional에 걸려 아무것도 저장 안되는 문제 수정
-  안 쓰는 플랜 안 쓰는 coworker를 지우기위한 함수 추가