### PR TITLE
refactor: data layer와 비즈니스 로직에서 사용하는 객체 분리

### DIFF
--- a/tripeer/src/main/java/com/j10d207/tripeer/exception/ErrorCode.java
+++ b/tripeer/src/main/java/com/j10d207/tripeer/exception/ErrorCode.java
@@ -75,7 +75,10 @@ public enum ErrorCode {
     INVALID_PAGE(HttpStatus.BAD_REQUEST, "VALID-003", "입력될 수 없는 페이지 값"),
 
     // Notification
-    NOT_FOUND_NOTI(HttpStatus.NOT_FOUND, "NOTI-001", "알림을 찾을 수 없습니다.")
+    NOT_FOUND_NOTI(HttpStatus.NOT_FOUND, "NOTI-001", "알림을 찾을 수 없습니다."),
+
+    // Notification
+    NOT_FOUND_NOTI_TASK(HttpStatus.NOT_FOUND, "NOTI-002", "처리해야 할 알림을 찾을 수 없습니다.")
     ;
 
 

--- a/tripeer/src/main/java/com/j10d207/tripeer/noti/controller/NotificationController.java
+++ b/tripeer/src/main/java/com/j10d207/tripeer/noti/controller/NotificationController.java
@@ -146,8 +146,8 @@ public class NotificationController {
 	public Response<Void> testDiarySave(
 		@AuthenticationPrincipal CustomOAuth2User user
 	) {
-		// publisher.publish();
-		testService.testDiaryNoti(user.getUserId());
+		publisher.publish();
+		// testService.testDiaryNoti(user.getUserId());
 		return Response.of(
 			HttpStatus.OK,
 			null,

--- a/tripeer/src/main/java/com/j10d207/tripeer/noti/db/entity/FirebaseToken.java
+++ b/tripeer/src/main/java/com/j10d207/tripeer/noti/db/entity/FirebaseToken.java
@@ -36,6 +36,13 @@ public class FirebaseToken {
             .build();
     }
 
+    public static FirebaseToken from(final Long tokenId, final String firebaseToken) {
+        return FirebaseToken.builder()
+            .id(tokenId)
+            .token(firebaseToken)
+            .build();
+    }
+
 
     private enum Mark {
         CHECKED,

--- a/tripeer/src/main/java/com/j10d207/tripeer/noti/db/entity/NotificationTask.java
+++ b/tripeer/src/main/java/com/j10d207/tripeer/noti/db/entity/NotificationTask.java
@@ -2,6 +2,7 @@ package com.j10d207.tripeer.noti.db.entity;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.ZoneId;
 
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -50,13 +51,13 @@ public class NotificationTask {
 	}
 
 	public boolean isImmediately() {
-		final LocalDate today =  LocalDate.now();
+		final LocalDate today =  LocalDate.now(ZoneId.of("Asia/Seoul"));
 		final LocalDate startDate = notification.getStartAt().toLocalDate();
 		return today.isAfter(startDate) || today.isEqual(startDate);
 	}
 
 	public boolean isScheduled() {
-		final LocalDate today =  LocalDate.now();
+		final LocalDate today =  LocalDate.now(ZoneId.of("Asia/Seoul"));
 		final LocalDate startDate = notification.getStartAt().toLocalDate();
 		return today.isBefore(startDate);
 	}

--- a/tripeer/src/main/java/com/j10d207/tripeer/noti/db/entity/NotificationTask.java
+++ b/tripeer/src/main/java/com/j10d207/tripeer/noti/db/entity/NotificationTask.java
@@ -1,9 +1,11 @@
 package com.j10d207.tripeer.noti.db.entity;
 
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.time.ZoneId;
 
+import com.j10d207.tripeer.noti.db.firebase.MessageType;
+import com.j10d207.tripeer.noti.dto.NotificationDto;
+import com.j10d207.tripeer.noti.dto.Token;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
@@ -33,7 +35,9 @@ public class NotificationTask {
 	@JoinColumn(name = "notification_id")
 	private Notification notification;
 
-	private String targetToken;
+	@ManyToOne
+	@JoinColumn(name = "target_token")
+	private FirebaseToken targetToken;
 
 	@Builder.Default
 	@Enumerated(EnumType.STRING)
@@ -43,10 +47,17 @@ public class NotificationTask {
 		WAIT, SENT;
 	}
 
-	public static NotificationTask of(final Notification notification, final String token) {
+	public static NotificationTask of(final NotificationDto notification, final Token token) {
 		return NotificationTask.builder()
-			.notification(notification)
-			.targetToken(token)
+			.notification(Notification.builder()
+					.id(notification.notificationId())
+					.userId(notification.userId())
+					.title(notification.title())
+					.msgType(MessageType.valueOf(notification.msgType()))
+					.content(notification.content())
+					.startAt(notification.startAt())
+					.build())
+			.targetToken(FirebaseToken.from(token.tokenId(), token.firebaseToken()))
 			.build();
 	}
 

--- a/tripeer/src/main/java/com/j10d207/tripeer/noti/db/firebase/MessageBuilder.java
+++ b/tripeer/src/main/java/com/j10d207/tripeer/noti/db/firebase/MessageBuilder.java
@@ -2,6 +2,7 @@ package com.j10d207.tripeer.noti.db.firebase;
 
 import com.google.firebase.messaging.Message;
 import com.google.firebase.messaging.WebpushConfig;
+import com.j10d207.tripeer.noti.dto.Token;
 
 public class MessageBuilder {
 
@@ -47,10 +48,10 @@ public class MessageBuilder {
 		return new MessageBody(title, content, MessageType.USER_INVITED);
 	}
 
-	public static Message toFirebaseMessage(final MessageBody messageBody, final String firebaseToken) {
+	public static Message toFirebaseMessage(final MessageBody messageBody, final Token token) {
 
 		return Message.builder()
-			.setToken(firebaseToken)
+			.setToken(token.firebaseToken())
 			.putAllData(messageBody.getBody())
 			.setWebpushConfig(WebpushConfig.builder()
 				.putHeader("ttl", "300")

--- a/tripeer/src/main/java/com/j10d207/tripeer/noti/dto/NotificationDto.java
+++ b/tripeer/src/main/java/com/j10d207/tripeer/noti/dto/NotificationDto.java
@@ -1,0 +1,12 @@
+package com.j10d207.tripeer.noti.dto;
+
+
+import lombok.Builder;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Builder
+public record NotificationDto(Long notificationId, Long userId, String title, String content, String msgType, LocalDateTime startAt) {
+
+}

--- a/tripeer/src/main/java/com/j10d207/tripeer/noti/dto/NotificationMap.java
+++ b/tripeer/src/main/java/com/j10d207/tripeer/noti/dto/NotificationMap.java
@@ -5,13 +5,13 @@ import java.util.Optional;
 
 public class NotificationMap {
 
-	private final Map<Long, Long> notificationMap;
+	private final Map<Long, NotificationDto> notificationMap;
 
-	public NotificationMap(final Map<Long, Long> notificationMap) {
-		this.notificationMap = notificationMap;
+	public NotificationMap(final Map<Long, NotificationDto> notificationMap) {
+		this.notificationMap = Map.copyOf(notificationMap);
 	}
 
-	public Optional<Long> getNotificationId(final Long userId) {
+	public Optional<NotificationDto> getNotification(final Long userId) {
 		return Optional.ofNullable(notificationMap.get(userId));
 	}
 }

--- a/tripeer/src/main/java/com/j10d207/tripeer/noti/dto/NotificationMap.java
+++ b/tripeer/src/main/java/com/j10d207/tripeer/noti/dto/NotificationMap.java
@@ -1,0 +1,17 @@
+package com.j10d207.tripeer.noti.dto;
+
+import java.util.Map;
+import java.util.Optional;
+
+public class NotificationMap {
+
+	private final Map<Long, Long> notificationMap;
+
+	public NotificationMap(final Map<Long, Long> notificationMap) {
+		this.notificationMap = notificationMap;
+	}
+
+	public Optional<Long> getNotificationId(final Long userId) {
+		return Optional.ofNullable(notificationMap.get(userId));
+	}
+}

--- a/tripeer/src/main/java/com/j10d207/tripeer/noti/dto/Token.java
+++ b/tripeer/src/main/java/com/j10d207/tripeer/noti/dto/Token.java
@@ -1,0 +1,9 @@
+package com.j10d207.tripeer.noti.dto;
+
+public record Token(String firebaseToken, Long tokenId) {
+
+    public static Token of(final String firebaseToken, final Long tokenId) {
+        return new Token(firebaseToken, tokenId);
+    }
+
+}

--- a/tripeer/src/main/java/com/j10d207/tripeer/noti/dto/TokenMap.java
+++ b/tripeer/src/main/java/com/j10d207/tripeer/noti/dto/TokenMap.java
@@ -1,0 +1,30 @@
+package com.j10d207.tripeer.noti.dto;
+
+import com.j10d207.tripeer.noti.dto.Token;
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+@Slf4j
+public class TokenMap {
+
+    private final Map<Long, List<Token>> tokenMap;
+
+    public TokenMap(final Map<Long, List<Token>> tokenMap) {
+        this.tokenMap = Map.copyOf(tokenMap);
+        log.info("tokenMap: {}", tokenMap);
+    }
+
+    public List<Token> getTokens(final Long userId) {
+        List<Token> tokens = tokenMap.getOrDefault(userId, Collections.emptyList());
+        if (tokens.isEmpty()) return tokens;
+        return List.copyOf(tokens);
+    }
+
+    public List<Long> getUserIds() {
+        return List.copyOf(tokenMap.keySet());
+    }
+
+}

--- a/tripeer/src/main/java/com/j10d207/tripeer/noti/mapper/FirebaseTokenMapper.java
+++ b/tripeer/src/main/java/com/j10d207/tripeer/noti/mapper/FirebaseTokenMapper.java
@@ -1,0 +1,29 @@
+package com.j10d207.tripeer.noti.mapper;
+
+import com.j10d207.tripeer.noti.db.entity.FirebaseToken;
+import com.j10d207.tripeer.noti.dto.Token;
+import com.j10d207.tripeer.noti.dto.TokenMap;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+public class FirebaseTokenMapper {
+
+    private FirebaseTokenMapper () {
+
+    }
+
+    public static TokenMap toTokenMap(final List<FirebaseToken> tokens) {
+        final Map<Long, List<Token>> tokenMap = tokens.stream()
+                .collect(Collectors.groupingBy(
+                        token -> token.getUser().getUserId(),
+                        Collectors.mapping(token -> Token.of(token.getToken(), token.getId()), Collectors.toList())
+                ));
+        return new TokenMap(tokenMap);
+    }
+
+    public static Token toTokenDto(final FirebaseToken token) {
+        return Token.of(token.getToken(), token.getId());
+    }
+}

--- a/tripeer/src/main/java/com/j10d207/tripeer/noti/mapper/NotificationMapper.java
+++ b/tripeer/src/main/java/com/j10d207/tripeer/noti/mapper/NotificationMapper.java
@@ -1,0 +1,37 @@
+package com.j10d207.tripeer.noti.mapper;
+
+import com.j10d207.tripeer.noti.db.entity.Notification;
+import com.j10d207.tripeer.noti.dto.NotificationDto;
+import com.j10d207.tripeer.noti.dto.NotificationMap;
+import com.j10d207.tripeer.noti.dto.Token;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+public class NotificationMapper {
+
+    private NotificationMapper() {
+
+    }
+
+    public static NotificationMap toNotificationMap(final List<Notification> notifications) {
+        final Map<Long, NotificationDto> notificationMap = notifications.stream()
+                .collect(Collectors.toMap(
+                        Notification::getUserId,
+                        NotificationMapper::toNotificationDto
+                ));
+        return new NotificationMap(notificationMap);
+    }
+
+    public static NotificationDto toNotificationDto(final Notification notification) {
+        return NotificationDto.builder()
+                .userId(notification.getUserId())
+                .notificationId(notification.getId())
+                .title(notification.getTitle())
+                .content(notification.getContent())
+                .msgType(notification.getMsgType().name())
+                .startAt(notification.getStartAt())
+                .build();
+    }
+}

--- a/tripeer/src/main/java/com/j10d207/tripeer/noti/mapper/NotificationTaskMapper.java
+++ b/tripeer/src/main/java/com/j10d207/tripeer/noti/mapper/NotificationTaskMapper.java
@@ -1,0 +1,11 @@
+package com.j10d207.tripeer.noti.mapper;
+
+import com.j10d207.tripeer.noti.db.entity.NotificationTask;
+
+public class NotificationTaskMapper {
+
+    private NotificationTaskMapper() {
+
+    }
+
+}

--- a/tripeer/src/main/java/com/j10d207/tripeer/noti/service/NotificationEventTestPublisher.java
+++ b/tripeer/src/main/java/com/j10d207/tripeer/noti/service/NotificationEventTestPublisher.java
@@ -24,7 +24,7 @@ public class NotificationEventTestPublisher {
 		publisher.publishEvent(CompletePlanEvent.builder()
 			.planTitle("내일 여행여행 테스트")
 				.coworkers(List.of(new CoworkerDto(75L, "김회창")))
-				.startAt(LocalDate.now().plusDays(1L))
+				.startAt(LocalDate.now())
 				.endAt(LocalDate.now().plusDays(2L))
 			.build());
 	}

--- a/tripeer/src/main/java/com/j10d207/tripeer/noti/service/NotificationService.java
+++ b/tripeer/src/main/java/com/j10d207/tripeer/noti/service/NotificationService.java
@@ -60,11 +60,11 @@ public class NotificationService {
 		final LocalDateTime startAt,
 		final Long targetId
 	) {
-		final Notification notificaiton = Notification.of(msgBody, userId, startAt, targetId);
+		final Notification notification = Notification.of(msgBody, userId, startAt, targetId);
 
-		notificationRepository.save(notificaiton);
+		notificationRepository.save(notification);
 
-		return notificaiton;
+		return notification;
 	}
 
 	@Transactional

--- a/tripeer/src/main/java/com/j10d207/tripeer/noti/service/NotificationService.java
+++ b/tripeer/src/main/java/com/j10d207/tripeer/noti/service/NotificationService.java
@@ -10,6 +10,8 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import com.j10d207.tripeer.noti.dto.NotificationMap;
+import com.j10d207.tripeer.noti.mapper.NotificationMapper;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -35,7 +37,7 @@ public class NotificationService {
 
 
 	@Transactional
-	public Map<Long, Notification> getNotificationMapAfterSave (
+	public NotificationMap getNotificationMapAfterSave (
 		final Map<Long, MessageBody> msgBodyMap,
 		final LocalDateTime startAt,
 		final Long targetId
@@ -46,15 +48,11 @@ public class NotificationService {
 
 		notificationRepository.saveAll(notifications);
 
-		return notifications.stream()
-			.collect(Collectors.toMap(
-				Notification::getUserId,
-				notification -> notification
-			));
+		return NotificationMapper.toNotificationMap(notifications);
 	}
 
 	@Transactional
-	public Notification getNotificationAfterSave(
+	public com.j10d207.tripeer.noti.dto.NotificationDto getNotificationAfterSave(
 		final MessageBody msgBody,
 		final Long userId,
 		final LocalDateTime startAt,
@@ -64,7 +62,7 @@ public class NotificationService {
 
 		notificationRepository.save(notification);
 
-		return notification;
+		return NotificationMapper.toNotificationDto(notification);
 	}
 
 	@Transactional

--- a/tripeer/src/main/java/com/j10d207/tripeer/noti/service/TestNotificationService.java
+++ b/tripeer/src/main/java/com/j10d207/tripeer/noti/service/TestNotificationService.java
@@ -6,6 +6,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.IntStream;
 
+import com.j10d207.tripeer.noti.dto.Token;
+import com.j10d207.tripeer.noti.mapper.FirebaseTokenMapper;
 import org.springframework.stereotype.Service;
 
 import com.google.firebase.FirebaseException;
@@ -48,10 +50,11 @@ public class TestNotificationService {
 		MessageBody msgBody = MessageBuilder.getMessageBody(MessageType.TRIPEER_START, planTitle, userNickname);
 
 		firebaseTokens.forEach(token -> {
+			final Token tokenDto = FirebaseTokenMapper.toTokenDto(token);
 			try {
-				firebasePublisher.sendFirebaseMessage(MessageBuilder.toFirebaseMessage(msgBody, token.getToken()));
+				firebasePublisher.sendFirebaseMessage(MessageBuilder.toFirebaseMessage(msgBody, tokenDto));
 			} catch (FirebaseException e) {
-				firebaseTokenService.invalidFirebaseHandler(token.getToken(), userId);
+				firebaseTokenService.invalidFirebaseHandler(tokenDto);
 			}
 
 		});
@@ -69,10 +72,11 @@ public class TestNotificationService {
 
 
 		firebaseTokens.forEach(token -> {
+			final Token tokenDto = FirebaseTokenMapper.toTokenDto(token);
 			try {
-				firebasePublisher.sendFirebaseMessage(MessageBuilder.toFirebaseMessage(msgBody, token.getToken()));
+				firebasePublisher.sendFirebaseMessage(MessageBuilder.toFirebaseMessage(msgBody, tokenDto));
 			} catch (FirebaseException e) {
-				firebaseTokenService.invalidFirebaseHandler(token.getToken(), userId);
+				firebaseTokenService.invalidFirebaseHandler(tokenDto);
 			}
 
 		});
@@ -88,11 +92,12 @@ public class TestNotificationService {
 
 
 		firebaseTokens.forEach(token -> {
+			final Token tokenDto = FirebaseTokenMapper.toTokenDto(token);
 			try {
 				log.info("target token : {}", token.getToken());
-				firebasePublisher.sendFirebaseMessage(MessageBuilder.toFirebaseMessage(msgBody, token.getToken()));
+				firebasePublisher.sendFirebaseMessage(MessageBuilder.toFirebaseMessage(msgBody, tokenDto));
 			} catch (FirebaseException e) {
-				firebaseTokenService.invalidFirebaseHandler(token.getToken(), token.getUser().getUserId());
+				firebaseTokenService.invalidFirebaseHandler(tokenDto);
 			}
 		});
 		notificationRepository.save(Notification.of(msgBody, userId, LocalDateTime.now(), planId));


### PR DESCRIPTION
## PR 유형
어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 주요 변경사항

- 기존에 서비스에서 다른서비스의 반환값을 사용할 때 entity를 그대로 사용하는 부분에 있어서 영속성 레이어와 비즈니스 레이어를 분리하지 않아, 트랜잭션 경계가 모호함을 발견함
- 따라서 각 도메인 서비스에서의 반환값을 DTO로 변환해줌

- NotificationTask 엔티티의 필드변경
- 기존에 해당 알림을 전달하기 위해 FirebaseToken 엔티티의 필드 하나만 필요해서 굳이 엔티티 매핑을 하지않았으나, 더많은 필드가 필요하여 연관관계 매핑해주었음
