### PR TITLE
feat: 이메일 서비스 레이어드 아키텍쳐 적용 및 헬프 데스크 구현

### DIFF
--- a/tripeer/src/main/java/com/j10d207/tripeer/common/SecurityConfig.java
+++ b/tripeer/src/main/java/com/j10d207/tripeer/common/SecurityConfig.java
@@ -121,6 +121,9 @@ public class SecurityConfig {
                         .requestMatchers(HttpMethod.PATCH, "/user/password").permitAll()
                         .requestMatchers(HttpMethod.POST, "/user/valid/email","/user/valid/password","user/login/custom", "user/signup/custom").permitAll()
 
+                        // 문의사항 이메일 관련
+                        .requestMatchers(HttpMethod.POST, "/email/helpdesk").permitAll()
+
                         //가입대기 상태 (소셜 로그인만 된 상태)
                         .requestMatchers(HttpMethod.POST, "/user/signup").hasAnyRole("VALIDATE")
                         // 가입대기 + 모든 사용자 => 닉네임 중복체크

--- a/tripeer/src/main/java/com/j10d207/tripeer/email/controller/EmailController.java
+++ b/tripeer/src/main/java/com/j10d207/tripeer/email/controller/EmailController.java
@@ -1,9 +1,12 @@
 package com.j10d207.tripeer.email.controller;
 
 
-import com.j10d207.tripeer.email.db.dto.EmailDTO;
+import com.j10d207.tripeer.email.dto.EmailDTO;
+import com.j10d207.tripeer.email.dto.req.Helpdesk;
 import com.j10d207.tripeer.email.service.EmailService;
 import com.j10d207.tripeer.response.Response;
+
+import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
@@ -22,6 +25,29 @@ public class EmailController {
 
     @PostMapping("")
     public Response<?> test(@RequestBody EmailDTO emailDTO) {
-        return Response.of(HttpStatus.OK, "이메일 전송 완료", emailService.sendEmail(emailDTO));
+        return Response.of(HttpStatus.OK, "이메일 전송 완료", emailService.sendSimpleEmail(emailDTO));
+    }
+
+    @PostMapping("/helpdesk")
+    public Response<?> helpdeskProcessor(@RequestBody Helpdesk helpdesk) {
+
+        emailService.sendHelpdesk(helpdesk);
+        return Response.of(
+            ResponseHeader.EMAIL_SENT.getStatus(),
+            ResponseHeader.EMAIL_SENT.getMessage(),
+            null
+        );
+    }
+
+    @Getter
+    @RequiredArgsConstructor
+    private enum ResponseHeader {
+
+        EMAIL_SENT("이메일 전송에 성공하였습니다.", HttpStatus.NO_CONTENT)
+        ;
+
+        private final String message;
+        private final HttpStatus status;
+
     }
 }

--- a/tripeer/src/main/java/com/j10d207/tripeer/email/db/EmailSender.java
+++ b/tripeer/src/main/java/com/j10d207/tripeer/email/db/EmailSender.java
@@ -1,0 +1,23 @@
+package com.j10d207.tripeer.email.db;
+
+import org.springframework.mail.MailException;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Repository;
+
+import com.j10d207.tripeer.email.dto.Email;
+
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+public class EmailSender {
+
+	private final JavaMailSender sender;
+
+	@Async
+	public void sendEmail(final Email email) throws MailException {
+
+		sender.send(email.getEmailMessage());
+	}
+}

--- a/tripeer/src/main/java/com/j10d207/tripeer/email/dto/Email.java
+++ b/tripeer/src/main/java/com/j10d207/tripeer/email/dto/Email.java
@@ -1,0 +1,85 @@
+package com.j10d207.tripeer.email.dto;
+
+import java.util.Arrays;
+
+import org.springframework.mail.javamail.MimeMessageHelper;
+import org.springframework.mail.javamail.MimeMessagePreparator;
+
+import lombok.Builder;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@RequiredArgsConstructor
+@Builder
+@Slf4j
+public class Email {
+
+	private final String to;
+
+	private final String subject;
+
+	private final String from;
+
+	private final String content;
+
+	private static final String SUBJECT_PREFIX = "[Tripeer] ";
+
+	private static final String SENDER_PREFIX = "보낸사람: ";
+
+	public MimeMessagePreparator getEmailMessage() {
+
+		return mimeMessage -> {
+			MimeMessageHelper messageHelper = new MimeMessageHelper(mimeMessage, true);
+			messageHelper.setTo(to);
+			messageHelper.setSubject(makeSubject(subject));
+
+			// HTML 컨텐츠 구성
+
+			String htmlBody = buildEmailContent(this.content, from);
+			if (from == null) htmlBody = buildEmailContent(this.content);
+			messageHelper.setText(htmlBody, true); // true는 HTML 메일을 보내겠다는 의미.
+		};
+	}
+
+	private String makeSubject(final String subject) {
+		return SUBJECT_PREFIX + subject;
+	}
+
+	private String buildEmailContent(final String messageContent, final String sender) {
+		final String htmlBody = makeEmailHtmlBody(messageContent, SENDER_PREFIX + sender);
+		return makeHtml(htmlBody);
+	}
+	private String buildEmailContent(final String messageContent) {
+		final String htmlBody = makeEmailHtmlBody(messageContent);
+		return makeHtml(htmlBody);
+	}
+
+	private String makeEmailHtmlBody(final String ...contents) {
+		String bodyHead = "<p style='font-size: 16px; line-height: 1.5; color: #333333;'>";
+		String bodyEnd = "</p>";
+		StringBuilder sb = new StringBuilder();
+		sb.append(bodyHead);
+		Arrays.stream(contents).forEach(content -> sb.append(bodyHead).append(content).append(bodyEnd));
+		return sb.toString();
+	}
+
+	private String makeHtml(final String messageContent) {
+		String body =
+				"<html>" +
+				"<body style='margin: 0; padding: 0; text-align: center; background-color: #f2f2f2;'>" +
+				"<div style='padding-top: 40px;'>" +  // 이미지 위의 패딩만 유지
+				"<img src='https://tripeer207.s3.ap-northeast-2.amazonaws.com/front/static/diaryBanner.png' alt='Tripper Welcome Image' style='width: 100%; height: auto; display: block; margin: 0 auto;'>" +  // 중앙 정렬
+				"<div style='margin: 0 auto; background: white; border-top: 5px solid #4FBDB7; border-bottom: 5px solid #04ACB5; padding: 40px 20px; font-family: Arial, sans-serif; box-shadow: 0 4px 8px rgba(0, 0, 0, 0.05); min-height: 330px; text-align: center;'>" +  // 기본 높이와 패딩 조정, 텍스트 중앙 정렬 추가
+				"<img src='https://tripeer207.s3.ap-northeast-2.amazonaws.com/front/static/title.png' alt='Tripper logo Image' style='max-width: 300px; width: 100%; height: auto; display: block; margin: 0 auto;'>" +
+				"<h2 style='color: #04ACB5; margin-top: 50px;'>안녕하세요! Tripper입니다.</h2>";
+		String end =
+				"</div>" +
+				"</body>" +
+				"</html>";
+		StringBuilder sb = new StringBuilder();
+
+		sb.append(body).append(messageContent).append(end);
+
+		return sb.toString();
+	}
+}

--- a/tripeer/src/main/java/com/j10d207/tripeer/email/dto/EmailDTO.java
+++ b/tripeer/src/main/java/com/j10d207/tripeer/email/dto/EmailDTO.java
@@ -1,4 +1,4 @@
-package com.j10d207.tripeer.email.db.dto;
+package com.j10d207.tripeer.email.dto;
 
 import lombok.AllArgsConstructor;
 import lombok.Builder;

--- a/tripeer/src/main/java/com/j10d207/tripeer/email/dto/req/Helpdesk.java
+++ b/tripeer/src/main/java/com/j10d207/tripeer/email/dto/req/Helpdesk.java
@@ -1,0 +1,6 @@
+package com.j10d207.tripeer.email.dto.req;
+
+
+public record Helpdesk(String sender, String subject, String content) {
+
+}

--- a/tripeer/src/main/java/com/j10d207/tripeer/email/service/EmailService.java
+++ b/tripeer/src/main/java/com/j10d207/tripeer/email/service/EmailService.java
@@ -1,9 +1,13 @@
 package com.j10d207.tripeer.email.service;
 
 
-import com.j10d207.tripeer.email.db.dto.EmailDTO;
+import com.j10d207.tripeer.email.dto.EmailDTO;
+import com.j10d207.tripeer.email.dto.req.Helpdesk;
 
 public interface EmailService {
 
-    public boolean sendEmail(EmailDTO emailDTO);
+    public boolean sendSimpleEmail(EmailDTO emailDTO);
+
+    void sendHelpdesk(final Helpdesk helpdesk);
+
 }

--- a/tripeer/src/main/java/com/j10d207/tripeer/email/service/EmailServiceImpl.java
+++ b/tripeer/src/main/java/com/j10d207/tripeer/email/service/EmailServiceImpl.java
@@ -1,7 +1,10 @@
 package com.j10d207.tripeer.email.service;
 
 
-import com.j10d207.tripeer.email.db.dto.EmailDTO;
+import com.j10d207.tripeer.email.db.EmailSender;
+import com.j10d207.tripeer.email.dto.Email;
+import com.j10d207.tripeer.email.dto.EmailDTO;
+import com.j10d207.tripeer.email.dto.req.Helpdesk;
 import com.j10d207.tripeer.exception.CustomException;
 import com.j10d207.tripeer.exception.ErrorCode;
 import com.j10d207.tripeer.user.db.entity.UserEntity;
@@ -18,11 +21,12 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class EmailServiceImpl implements EmailService{
 
-    private final JavaMailSender javaMailSender;
     private final UserRepository userRepository;
+    private final EmailSender emailSender;
 
+    private static final String HELP_DESK_RECEIVER = "tripeer207@gmail.com";
     @Override
-    public boolean sendEmail(EmailDTO emailDTO) {
+    public boolean sendSimpleEmail(EmailDTO emailDTO) {
         UserEntity userEntity = userRepository.findById(emailDTO.getUserId())
                 .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
         String email = userEntity.getEmail();
@@ -31,19 +35,15 @@ public class EmailServiceImpl implements EmailService{
             return false;
         }
 
-        MimeMessagePreparator messagePreparator = mimeMessage -> {
-            MimeMessageHelper messageHelper = new MimeMessageHelper(mimeMessage, true);
-            messageHelper.setTo(userEntity.getEmail());
-            messageHelper.setSubject("[Tripeer] " + emailDTO.getTitle());
-            messageHelper.setFrom("hmy940424@gmail.com");
-
-            // HTML 컨텐츠 구성
-            String content = buildEmailContent(emailDTO.getContent());
-            messageHelper.setText(content, true); // true는 HTML 메일을 보내겠다는 의미.
-        };
+        final Email post = Email.builder()
+            .subject(emailDTO.getTitle())
+            .content(emailDTO.getContent())
+            .to(email)
+            .from(null)
+            .build();
 
         try {
-            javaMailSender.send(messagePreparator);
+            emailSender.sendEmail(post);
             return true;
         } catch (Exception e) {
 //            throw new CustomException(ErrorCode.EMAIL_NOT_FOUND);
@@ -51,22 +51,21 @@ public class EmailServiceImpl implements EmailService{
         }
     }
 
+    @Override
+    public void sendHelpdesk(final Helpdesk helpdesk) {
 
+        final Email post = Email.builder()
+            .subject(helpdesk.subject())
+            .content(helpdesk.content())
+            .to(HELP_DESK_RECEIVER)
+            .from(helpdesk.sender())
+            .build();
 
-    private String buildEmailContent(String messageContent) {
-        return "<html>" +
-                "<body style='margin: 0; padding: 0; text-align: center; background-color: #f2f2f2;'>" +
-                "<div style='padding-top: 40px;'>" +  // 이미지 위의 패딩만 유지
-                "<img src='https://tripeer207.s3.ap-northeast-2.amazonaws.com/front/static/diaryBanner.png' alt='Tripper Welcome Image' style='width: 100%; height: auto; display: block; margin: 0 auto;'>" +  // 중앙 정렬
-                "<div style='margin: 0 auto; background: white; border-top: 5px solid #4FBDB7; border-bottom: 5px solid #04ACB5; padding: 40px 20px; font-family: Arial, sans-serif; box-shadow: 0 4px 8px rgba(0, 0, 0, 0.05); min-height: 330px; text-align: center;'>" +  // 기본 높이와 패딩 조정, 텍스트 중앙 정렬 추가
-                "<img src='https://tripeer207.s3.ap-northeast-2.amazonaws.com/front/static/title.png' alt='Tripper logo Image' style='max-width: 300px; width: 100%; height: auto; display: block; margin: 0 auto;'>" +
-                "<h2 style='color: #04ACB5; margin-top: 50px;'>안녕하세요! Tripper입니다.</h2>" +
-                "<p style='font-size: 16px; line-height: 1.5; color: #333333;'>" + messageContent + "</p>" +
-                "</div>" +
-                "</body>" +
-                "</html>";
+        try {
+            emailSender.sendEmail(post);
+        } catch (Exception e) {
+            log.info("문제가 발생함: {}", e);
+        }
     }
-
-
 
 }

--- a/tripeer/src/main/java/com/j10d207/tripeer/plan/service/PlanSchedulerService.java
+++ b/tripeer/src/main/java/com/j10d207/tripeer/plan/service/PlanSchedulerService.java
@@ -1,6 +1,6 @@
 package com.j10d207.tripeer.plan.service;
 
-import com.j10d207.tripeer.email.db.dto.EmailDTO;
+import com.j10d207.tripeer.email.dto.EmailDTO;
 import com.j10d207.tripeer.email.service.EmailService;
 import com.j10d207.tripeer.plan.db.entity.PlanEntity;
 import com.j10d207.tripeer.plan.db.repository.PlanRepository;
@@ -47,7 +47,7 @@ public class PlanSchedulerService {
                 .title("내일 여행이 시작됩니다.")
                 .content(startDate + "부터 여행이 시작됩니다! 여행계획을 확인해보세요!")
                 .build();
-        emailService.sendEmail(emailDTO);
+        emailService.sendSimpleEmail(emailDTO);
     }
 
     // 종료 날짜에 실행할 메서드
@@ -58,6 +58,6 @@ public class PlanSchedulerService {
                 .title("여행 잘 다녀 오셨나요?")
                 .content("다이어리에서 "+ title + "여행의 추억을 확인해보세요!")
                 .build();
-        emailService.sendEmail(emailDTO);
+        emailService.sendSimpleEmail(emailDTO);
     }
 }


### PR DESCRIPTION
## PR 유형
어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 주요 변경사항

- 기존에 EmailDTO를 db 패키지에서 dto 패키지로 옮김

- Email을 보내는 주체는 외부 서비스라고 간주하여 db 패키지에 EmailSender 빈을 추가함
   -  이에 따라 EmailServiceImpl에서 이메일을 발송하는 역할을 EmailSender로 옮기고 기존의 sendEmail 메소드명을 sendSimpeEmail로 변경
   - email 도메인 객체 Email 추가
       - 해당 도메인객체에서 이제 email에 들어갈 Mime html body 를 생성하는 역할을 수행
       - 특히 from의 경우 어짜피 Spring mail yml을 따라가기에, from은 nullable 해도 됨 

- helpdesk 이메일 보내는 API 추가
  - /email/helpdesk 의 POST 매핑 추가
